### PR TITLE
Prevent truncating lines with get_inline_math

### DIFF
--- a/notion2md/exporter.py
+++ b/notion2md/exporter.py
@@ -357,4 +357,4 @@ def get_inline_math(block):
             text += "$$"+list[1][0][1]+"$$"
         else:
             text += list[0]
-        return text
+    return text


### PR DESCRIPTION
This fixes `get_inline_math` to return outside the loop instead of inside, which was truncating text blocks at the first special inline component (like italic text, or a link).