### PR TITLE
Add table block_type support and fix encoding utf-8 in test_block.py

### DIFF
--- a/Test/test_block.py
+++ b/Test/test_block.py
@@ -11,7 +11,7 @@ class ExportBlocksTest(unittest.TestCase):
             block_id=specific_block_id
         )
         print(blocks_convertor(test_blocks['results']))
-        with open('output.md','w') as file:
+        with open('output.md','w',encoding="utf-8") as file:
             file.write(blocks_convertor(test_blocks['results']))
 
 if __name__ == "__main__":


### PR DESCRIPTION
I have provided a parser for the notion table format, which converts notion tables into markdown tables. 
Also, I fixed encoding utf-8  in test_block.py
notion table:
<img width="298" alt="table" src="https://user-images.githubusercontent.com/31941418/150285826-ed1cf2b8-0948-4738-9bc8-b1c7f9d5aa90.png">

markdown table:

 | table | **price** | *number* |
 | ---- | ---- | ---- |
 | computer | <u>1600</u> | ~~5~~ |
 | moblie | $ \sum{x} $ | `12` |
 | 管线 |  (2022-01-20 → )  | [234](http://www.bilibili.com) |



