### PR TITLE
fix: change the way to get filename from url

### DIFF
--- a/notion2md/convertor/file.py
+++ b/notion2md/convertor/file.py
@@ -1,5 +1,7 @@
 from turtle import down
 import urllib.request as request
+from urllib.parse import urlparse
+import os
 import re
 from notion2md import console
 
@@ -12,7 +14,7 @@ def internal_downloader(url:str) -> str:
 # whether the file is downloadable or not,
 # there is no external file downloader
 def external_img_downlaoder(url:str) -> str:
-    filename = re.search("[.\-\w]+(?=\?)",url).group(0) + ".jpg"
+    filename = os.path.basename(urlparse(url).path)
     downlaoder(url,filename)
     return filename
 


### PR DESCRIPTION
I changed the way to get  filename from url to make it more general. You could test the  code.

Here is one of my examples, It can be seen that using the original way does not  work for url that end directly with *.gif

if it work's good, You could change the way to get  filename in `internal_downloader` function to this as well

``` bash
$ python
Python 3.8.10 (default, Jun  4 2021, 15:09:15)
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> import os
>>> from urllib.parse import urlparse
>>> url1 = 'https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f65637f2-8d1b-4d26-bb44-e57c26acdf8b/ssss.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220121%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220121T124722Z&X-Amz-Expires=3600&X-Amz-Signature=4c7e1132174fe57d8da8d32235718d097d48c3452dbc5c36f18dcea1dfa99690&X-Amz-SignedHeaders=host&x-id=GetObject'
>>> url2 = 'http://www.**.net/images/logo.gif'
>>> url3 = 'https://www.drupal.org/files/styles/grid-3-2x/public/images/nodereference_url.png?itok=_iY-wYF-'
>>> re.search("[.\-\w]+(?=\?)",url1).group(0)
'ssss.png'
>>> re.search("[.\-\w]+(?=\?)",url2).group(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'group'
>>> re.search("[.\-\w]+(?=\?)",url3).group(0)
'nodereference_url.png'
>>> os.path.basename(urlparse(url1).path)
'ssss.png'
>>> os.path.basename(urlparse(url2).path)
'logo.gif'
>>> os.path.basename(urlparse(url3).path)
'nodereference_url.png'
```