### PR TITLE
Fix:Change method name

### DIFF
--- a/notion2md/exporter.py
+++ b/notion2md/exporter.py
@@ -5,7 +5,7 @@ import time
 from notion2md.console import print_status,print_error
 from notion2md.config_store import set_config,get_config
 
-def block_makrdown_exporter(**kargs):
+def block_markdown_exporter(**kargs):
     set_config(**kargs)
     config = get_config()
 


### PR DESCRIPTION
- Method name block_markdown_exporter was wrong.
- Because of which getting error while importing
- Fixed the issue in the PR