### PR TITLE
Close #44

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ exclude = ["Test/test_*"]
 
 [tool.poetry.dependencies]
 python = ">=3.7, <4"
-notion-client = ">=1.0.1"
-cleo = "1.0.0a4"
+notion-client = ">=1.0.0"
+cleo = ">=1.0.0a4"
 
 [tool.poetry.scripts]
 notion2md = 'notion2md.console.application:main'


### PR DESCRIPTION
Thanks to @pyMixin, found dependencies requirements are broken

Fix notion-client version requirement from 1.0.1 to 1.0.0
Change Cleo's version requirement too from exaclty 1.0.0a4 to 1.0.0a4 above