### PR TITLE
fix: Add support for link_preview and fix a bug

### DIFF
--- a/notion2md/convertor/block.py
+++ b/notion2md/convertor/block.py
@@ -308,6 +308,10 @@ def synced_block(info: list) -> str:
     return "[//]: # (Synced Block)"
 
 
+def link_preview(info: dict) -> str:
+    url = info["url"]
+    return f"[{url}]({url})"
+
 # Block type map
 BLOCK_TYPES = {
     "paragraph": paragraph,
@@ -330,4 +334,5 @@ BLOCK_TYPES = {
     "file": file,
     "table_row": table_row,
     "synced_block": synced_block,
+    "link_preview": link_preview,
 }

--- a/notion2md/convertor/richtext.py
+++ b/notion2md/convertor/richtext.py
@@ -36,11 +36,11 @@ def equation(content: str):
 
 
 annotation_map = {
+    "code": code,
     "bold": bold,
     "italic": italic,
     "strikethrough": strikethrough,
     "underline": underline,
-    "code": code,
 }
 
 

--- a/tests/test_richtext_convertor.py
+++ b/tests/test_richtext_convertor.py
@@ -284,7 +284,7 @@ class ExportRichTextTest(unittest.TestCase):
             "href": None,
         }
         self.assertEqual(
-            richtext_word_converter(richtext), "`<u>~~***multiple***~~</u>`"
+            richtext_word_converter(richtext), "<u>~~***`multiple`***~~</u>"
         )
 
     def test_text_color_type(self):


### PR DESCRIPTION
1. See https://developers.notion.com/reference/block#link-preview.
2. When there are both inline blocks and styles (e.g. bold), the backquote should be at the innermost part, otherwise the style is not represented.
  For example, ![image](https://github.com/echo724/notion2md/assets/49866772/8fdd0256-5fe0-4296-9f4f-b443a876531d) This should be converted to ``**`some text`**``, instead of `` `**some text**` ``。
  ``**`some text`**``: **`some text`**
  `` `**some text**` ``: `**some text**`
  