### PR TITLE
feat: add notion token parameter to `Exporter`

### DIFF
--- a/notion2md/console/commands/export_block.py
+++ b/notion2md/console/commands/export_block.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 
@@ -11,7 +10,6 @@ from notion2md.console.formatter import success
 from notion2md.console.ui.indicator import progress
 from notion2md.exporter.block import CLIExporter
 
-
 ARGS_NEW_KEY_MAP = {
     "id": "block_id",
     "url": "block_url",
@@ -19,6 +17,7 @@ ARGS_NEW_KEY_MAP = {
     "path": "output_path",
     "download": "download",
     "unzipped": "unzipped",
+    "token": "token",
 }
 
 
@@ -27,6 +26,7 @@ class ExportBlockCommand(Command):
     description = "Export a Notion block object to markdown."
 
     options = [
+        option("token", "t", "The token of your Notion account.", flag=False),
         option("url", "u", "The url of Notion block object.", flag=False),
         option("id", "i", "The id of Notion block object.", flag=False),
         option("name", "n", "The name of Notion block object", flag=False),

--- a/notion2md/exporter/block.py
+++ b/notion2md/exporter/block.py
@@ -16,6 +16,7 @@ class Exporter:
         output_path: str = None,
         download: bool = False,
         unzipped: bool = False,
+        token: str = None,
     ):
         self._config = Config(
             block_id=block_id,
@@ -25,7 +26,7 @@ class Exporter:
             download=download,
             unzipped=unzipped,
         )
-        self._client = NotionClient()
+        self._client = NotionClient(token)
         self._io = None
         self._block_convertor = None
 

--- a/notion2md/notion_api.py
+++ b/notion2md/notion_api.py
@@ -8,9 +8,9 @@ from notion2md.exceptions import MissingTokenError
 def singleton(cls):
     instance = {}
 
-    def get_instance():
+    def get_instance(token=""):
         if cls not in instance:
-            instance[cls] = cls()
+            instance[cls] = cls(token)
         return instance[cls]
 
     return get_instance
@@ -18,8 +18,9 @@ def singleton(cls):
 
 @singleton
 class NotionClient:
-    def __init__(self):
-        token = self._get_env_variable()
+    def __init__(self, token=""):
+        if not token:
+            token = self._get_env_variable()
         self._client = Client(auth=token)
 
     def _get_env_variable(self):


### PR DESCRIPTION
### References
fix: #51

### Description
Added `token` parameter to `Exporter` to take the token not only from env but also from an argument. 

### Note
I do not know why but it has been deleted from main feature. I add this to main so that it can be added to the distribution.